### PR TITLE
Feature: Hinzufügen von Textstatistik-Funktion

### DIFF
--- a/src/main/java/de/htw_berlin/fb4/elise/App.java
+++ b/src/main/java/de/htw_berlin/fb4/elise/App.java
@@ -32,6 +32,11 @@ public class App
         Sentence s1 = new SimpleSentence();
         ProseBuilder proseBuilder = new ProseBuilder();
         proseBuilder.register(s1);
-        System.out.println(proseBuilder.get());
+        
+        String generatedText = proseBuilder.get();
+        System.out.println(generatedText);
+        
+        // Display statistics for the generated text
+        System.out.println(TextStatistics.generateStatisticsReport(generatedText));
     }
 }

--- a/src/main/java/de/htw_berlin/fb4/elise/TextStatistics.java
+++ b/src/main/java/de/htw_berlin/fb4/elise/TextStatistics.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2025 eliseHtw
+ *
+ * This program is free software under the terms of GPLv3.
+ * See the GNU General Public License for more details.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package de.htw_berlin.fb4.elise;
+
+/**
+ * Utility class to analyze text and provide statistics.
+ */
+public class TextStatistics {
+    
+    /**
+     * Counts the number of words in a text.
+     * 
+     * @param text the text to analyze
+     * @return the number of words
+     */
+    public static int countWords(String text) {
+        if (text == null || text.isEmpty()) {
+            return 0;
+        }
+        return text.split("\\s+").length;
+    }
+
+    /**
+     * Counts only the letters in a text (no spaces or punctuation marks).
+     * 
+     * @param text the text to analyze
+     * @return the number of letters
+     */
+    public static int countLettersOnly(String text) {
+        if (text == null || text.isEmpty()) {
+            return 0;
+        }
+        return text.replaceAll("[^a-zA-ZäöüÄÖÜß]", "").length();
+    }
+    
+    /**
+     * Counts the number of characters in a text, excluding leading and trailing whitespace.
+     * 
+     * @param text the text to analyze
+     * @return the number of characters (without leading/trailing whitespace)
+     */
+    public static int countCharacters(String text) {
+        if (text == null) {
+            return 0;
+        }
+        return text.trim().length();
+    }
+    
+    /**
+     * Counts the number of sentences in a text based on sentence-ending punctuation.
+     * 
+     * @param text the text to analyze
+     * @return the number of sentences
+     */
+    public static int countSentences(String text) {
+        if (text == null || text.isEmpty()) {
+            return 0;
+        }
+        return text.split("[.!?]+").length;
+    }
+    
+    /**
+     * Estimates the reading time in seconds based on an average reading speed of 200 words per minute.
+     * 
+     * @param text the text to analyze
+     * @return the estimated reading time in seconds
+     */
+    public static int estimateReadingTimeInSeconds(String text) {
+        int words = countWords(text);
+        // 200 words per minute = 3.333... words per second
+        return (int) Math.ceil(words / 3.333);
+    }
+    
+    /**
+     * Generates a complete statistics report for a given text.
+     * 
+     * @param text the text to analyze
+     * @return a formatted string containing the statistics
+     */
+    public static String generateStatisticsReport(String text) {
+        int words = countWords(text);
+        int characters = countCharacters(text);
+        int lettersOnly = countLettersOnly(text);
+        int sentences = countSentences(text);
+        int readingTimeSeconds = estimateReadingTimeInSeconds(text);
+        
+        return String.format(
+            "Statistik für mit ProseBuilder generierten Text:\n" +
+            "------------------------------------------------\n" +
+            "Wörter: %d\n" +
+            "Zeichen (gesamt): %d\n" +
+            "Buchstaben (ohne Leerzeichen/Satzzeichen): %d\n" +
+            "Sätze: %d\n" +
+            "Geschätzte Lesezeit: %d Sekunden",
+            words, characters, lettersOnly, sentences, readingTimeSeconds
+        );
+    }
+    
+}


### PR DESCRIPTION
## Description

Diese PR fügt eine neue Textstatistik-Funktion zur App hinzu. Die Implementierung berechnet statistische Informationen zu dem mit dem ProseBuilder generierten Text (Wortanzahl, Zeichenanzahl – mit und ohne Leerzeichen, Satzanzahl und geschätzte Lesezeit) und zeigt diese an. Die Funktionalität ist als unabhängige Utility-Klasse implementiert.

## Related Issues

Fixes #2

*Use keywords like `Closes` or `Fixes` to automatically link and close issues when 
the PR is merged.*

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update (e.g., README, Javadoc)
- [ ] Test improvement
- [ ] Other (please describe): __________

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, especially in complex areas
- [ ] I have updated the documentation (if applicable)
- [ ] I have added or updated tests (if applicable)
- [ ] All new and existing tests pass
- [x] I have verified the application runs correctly
- [ ] The CI pipeline passes (e.g., GitHub Actions)

## How to Test

So können die Änderungen getestet werden:

- Starte die Anwendung
- Überprüfe die Konsolenausgabe:
Der generierte Text sollte angezeigt werden
Direkt darunter sollten die Textstatistiken erscheinen (Wörter, Zeichen (gesamt), Buchstaben (ohne Leerzeichen/Satzzeichen), Sätze und Lesezeit)

## Screenshot

![Bildschirmfoto 2025-06-29 um 22 02 41](https://github.com/user-attachments/assets/b70c389a-4796-4264-970c-713d6f85529c)
